### PR TITLE
Change "valid until" to "valid through"

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Generating a CSIG for a build:
 Validating an asset using a CSIG:
 
 1. Extract and validate the intermediate certificate against the root public key.
-1. Check that the intermediate certificate remains valid (today in UTC is not after the valid-until date).
+1. Check that the intermediate certificate remains valid (today in UTC is not after the valid-through date).
 1. Extract the intermediate public key from the now-validated intermediate certificate.
 1. Extract the signed checksum list.
 1. Validate the signed checksum list against the intermediate public key.
@@ -91,7 +91,7 @@ Bold lines are annotations that do not occur in the CSIG.
   * Untrusted Comment (line #1)
   * Base64-Encoded Signature by Root Secret Key (line #2)
   * **Message is an expiring public key, or xpub**
-    * Valid Until Date in UTC in YYYY-MM-DD Format (line #3)
+    * Valid Through Date in UTC in YYYY-MM-DD Format (line #3)
     * **Build Infrastructure Public Key in Signify Format**  
       * "Untrusted" Comment (line #4)
       * Base64-Encoded Public Key (Build Infrastructure Key) (line #5)
@@ -138,7 +138,7 @@ Requisite files: `root.pub` `module.zip` `module.csig`
 
     $ head --lines=5 module.csig > intermediate.xpub.sig
     $ signify -V -e -p root.pub -m intermediate.xpub  # Verifies/extracts intermediate.xpub.sig, creates intermediate.xpub
-    $ head --lines=1 intermediate.xpub  # Displays valid-until date in UTC. Should be on or after the current date in UTC.
+    $ head --lines=1 intermediate.xpub  # Displays valid-through date in UTC. Should be on or after the current date in UTC.
     $ tail --lines=2 intermediate.xpub > intermediate.pub
     $ tail --lines=+6 module.csig | signify -C -p intermediate.pub -x -
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Bold lines are annotations that do not occur in the CSIG.
   * Base64-Encoded Signature by Root Secret Key (line #2)
   * **Message is an expiring public key, or xpub**
     * Valid Through Date in UTC in YYYY-MM-DD Format (line #3)
-    * **Build Infrastructure Public Key in Signify Format**  
+    * **Build Infrastructure Public Key in Signify Format**
       * "Untrusted" Comment (line #4)
       * Base64-Encoded Public Key (Build Infrastructure Key) (line #5)
 * **Message or Checksum List signed with key on lines 4-5**

--- a/sh/validate_csig.sh
+++ b/sh/validate_csig.sh
@@ -26,16 +26,16 @@ head -n 5 $csigfile > $intsig
 
 message1=$(mktemp /tmp/intsigmsg.XXXXXX)
 signify -V -e -x $intsig -p $rootpubkey -m $message1
-expiration=$(head -n 1 $message1)
+validthrough=$(head -n 1 $message1)
 
 intpubkey=$(mktemp /tmp/intsigmsg.XXXXXX)
 tail -n +2 $message1 > $intpubkey
 
 
 today=$(date -u +%Y-%m-%d)
-expiration=$(head -n 1 $message1)
-if [[ "$today" > "$expiration" ]] ; then
-  >&2 echo "Intermediate key was valid until $expiration (today is $today in UTC)"
+validthrough=$(head -n 1 $message1)
+if [[ "$today" > "$validthrough" ]] ; then
+  >&2 echo "Intermediate key was valid through $validthrough (today is $today in UTC)"
   exit 1
 fi
 

--- a/src/Verifier.php
+++ b/src/Verifier.php
@@ -277,7 +277,7 @@ class Verifier
         $valid_through_dt = \DateTimeImmutable::createFromFormat('Y-m-d', $csig_lines[2], new \DateTimeZone('UTC'));
         if (! $valid_through_dt instanceof \DateTimeImmutable)
         {
-            throw new VerifierException('Unexpected valid-until date format.');
+            throw new VerifierException('Unexpected valid-through date format.');
         }
         $now_dt = $this->getNow();
 


### PR DESCRIPTION
I think "valid through" reflects the intent more than "until." To me, "until" still leaves it ambiguous about whether the expiration is at the beginning or end of the specified date.